### PR TITLE
Set created_at only when isNew

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function timestamps(opts) {
     schema.add({ updated_at: Date, created_at: Date });
     schema.pre('save', function(next){
       var timestamp = new Date();
-      this.created_at = this.created_at || timestamp;
+      this.isNew && (this.created_at = timestamp);
       this.updated_at = timestamp;
       next();
     });


### PR DESCRIPTION
Otherwise, loading documents without the "created_at" field and saving them causes the creation time to be re-set to the current time.

Using isNew is more accurate and can prevent that from happening.
